### PR TITLE
Add null to possible return types from parsing functions

### DIFF
--- a/lib/email-addresses.d.ts
+++ b/lib/email-addresses.d.ts
@@ -1,9 +1,9 @@
 declare module emailAddresses {
-    function parseOneAddress(input: string | Options): ParsedMailbox | ParsedGroup;
-    function parseAddressList(input: string | Options): (ParsedMailbox | ParsedGroup)[];
-    function parseFrom(input: string | Options): (ParsedMailbox | ParsedGroup)[];
-    function parseSender(input: string | Options): ParsedMailbox | ParsedGroup;
-    function parseReplyTo(input: string | Options): (ParsedMailbox | ParsedGroup)[];
+    function parseOneAddress(input: string | Options): ParsedMailbox | ParsedGroup | null;
+    function parseAddressList(input: string | Options): (ParsedMailbox | ParsedGroup)[] | null;
+    function parseFrom(input: string | Options): (ParsedMailbox | ParsedGroup)[] | null;
+    function parseSender(input: string | Options): ParsedMailbox | ParsedGroup | null;
+    function parseReplyTo(input: string | Options): (ParsedMailbox | ParsedGroup)[] | null;
 
     interface ParsedMailbox {
         node?: ASTNode;


### PR DESCRIPTION
All of these can return `null` if parsing fails for any reason, so the type definitions should reflect that.