### PR TITLE
Use literal types to allow discriminated unions

### DIFF
--- a/lib/email-addresses.d.ts
+++ b/lib/email-addresses.d.ts
@@ -14,7 +14,7 @@ declare module emailAddresses {
             domain: ASTNode;
             comments: ASTNode[];
         };
-        type: string;
+        type: "mailbox";
         name: string;
         address: string;
         local: string;
@@ -26,7 +26,7 @@ declare module emailAddresses {
         parts: {
             name: ASTNode;
         };
-        type: string;
+        type: "group";
         name: string;
         addresses: ParsedMailbox[];
     }


### PR DESCRIPTION
See https://basarat.gitbooks.io/typescript/docs/types/discriminated-unions.html - this will allow TypeScript to narrow types when checking equality on the `type` field.