### PR TITLE
Fixes to library to parse  "some@email.com (comments) <some@email.com>"

### DIFF
--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -893,7 +893,7 @@ function parse5322(opts) {
     function giveResultMailbox(mailbox) {
         var name = findNode('display-name', mailbox);
         var aspec = findNode('addr-spec', mailbox);
-        var comments = findAllNodes('comment', mailbox);
+        var comments = findAllNodesNoChildren(['comment'], mailbox);
 
 
         var local = findNode('local-part', aspec);

--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -661,7 +661,7 @@ function parse5322(opts) {
     function obsPhrase() {
         return opts.strict ? null : wrap('obs-phrase', and(
             word,
-            star(or(word, literal('.'), colwsp(cfws)))
+            star(or(word, literal('.'), literal('@'), colwsp(cfws)))
         )());
     }
 
@@ -893,7 +893,8 @@ function parse5322(opts) {
     function giveResultMailbox(mailbox) {
         var name = findNode('display-name', mailbox);
         var aspec = findNode('addr-spec', mailbox);
-        var comments = findAllNodes('cfws', mailbox);
+        var comments = findAllNodes('comment', mailbox);
+
 
         var local = findNode('local-part', aspec);
         var domain = findNode('domain', aspec);
@@ -911,6 +912,7 @@ function parse5322(opts) {
             address: grabSemantic(aspec),
             local: grabSemantic(local),
             domain: grabSemantic(domain),
+            comments: concatComments(comments),
             groupName: grabSemantic(mailbox.groupName),
         };
     }
@@ -924,6 +926,16 @@ function parse5322(opts) {
         if (result && result.addresses) {
             for (i = 0; i < result.addresses.length; i += 1) {
                 delete result.addresses[i].node;
+            }
+        }
+        return result;
+    }
+
+    function concatComments(comments) {
+        let result = '';
+        if (comments) {
+            for (let i = 0; i < comments.length; i += 1) {
+                result += grabSemantic(comments[i]);
             }
         }
         return result;

--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -659,9 +659,14 @@ function parse5322(opts) {
 
     // obs-phrase      =   word *(word / "." / CFWS)
     function obsPhrase() {
-        return opts.strict ? null : wrap('obs-phrase', and(
+        if (opts.strict ) return null;
+        return opts.atInDisplayName ? wrap('obs-phrase', and(
             word,
             star(or(word, literal('.'), literal('@'), colwsp(cfws)))
+        )()) :
+        wrap('obs-phrase', and(
+            word,
+            star(or(word, literal('.'), colwsp(cfws)))
         )());
     }
 
@@ -1058,6 +1063,7 @@ function handleOpts(opts, defs) {
         simple: false,
         startAt: 'address-list',
         strict: false,
+        atInDisplayName: false
     };
 
     for (o in defaults) {

--- a/test/email-addresses.js
+++ b/test/email-addresses.js
@@ -36,7 +36,7 @@ test("simple one address function", function (t) {
 test("address with @ in the name", function (t) {
     var fxn, result;
     fxn = addrs.parseOneAddress;
-    result = fxn("ABC@abc (comment) < a@b.c>") || {};
+    result = fxn({input: "ABC@abc (comment) < a@b.c>", atInDisplayName: true }) || {};
     t.equal(result.name, "ABC@abc", "display name");
     t.end();
 });
@@ -44,7 +44,7 @@ test("address with @ in the name", function (t) {
 test("address with comments", function (t) {
     var fxn, result;
     fxn = addrs.parseOneAddress;
-    result = fxn("ABC (comment) < a@b.c>") || {};
+    result = fxn("ABC (comment) < a@b.c>" ) || {};
     t.equal(result.name, "ABC", "display name");
     t.equal(result.comments, '(comment)');
     t.end();

--- a/test/email-addresses.js
+++ b/test/email-addresses.js
@@ -33,6 +33,23 @@ test("simple one address function", function (t) {
     t.end();
 });
 
+test("address with @ in the name", function (t) {
+    var fxn, result;
+    fxn = addrs.parseOneAddress;
+    result = fxn("ABC@abc (comment) < a@b.c>") || {};
+    t.equal(result.name, "ABC@abc", "display name");
+    t.end();
+});
+
+test("address with comments", function (t) {
+    var fxn, result;
+    fxn = addrs.parseOneAddress;
+    result = fxn("ABC (comment) < a@b.c>") || {};
+    t.equal(result.name, "ABC", "display name");
+    t.equal(result.comments, '(comment)');
+    t.end();
+});
+
 test("simple address list function", function (t) {
     var fxn, result;
     fxn = addrs.parseAddressList;


### PR DESCRIPTION
There are a lot of mail addresses written in the form `some@email.com (comments) <some@email.com>`
Currently library does not parse them correctly. (it would output `undefined` when parsing this name)

This is causing some issues with pgp (pretty good privacy) realisations:
https://github.com/openpgpjs/openpgpjs/issues/918

In this pull request I fix this behaviour to correctly parse displayName with `@`. Secondly comments are correctly parsed and outputted as concatenated string.