### PR TITLE
bug fix: added domain as part of the ParsedGroup return type

### DIFF
--- a/lib/email-addresses.d.ts
+++ b/lib/email-addresses.d.ts
@@ -29,6 +29,7 @@ declare module emailAddresses {
         type: string;
         name: string;
         addresses: ParsedMailbox[];
+        domain: string;
     }
 
     interface ASTNode {


### PR DESCRIPTION
I'd like to suggest adding the domain to the ParsedGroup return type because this basic example isn't working as expected.

```
import { parseOneAddress } from 'email-addresses'

let email: string = 'aymather@gmail.com'
const parsed = parseOneAddress(email)
console.log(parsed.domain)
```

It is telling me:
```
Property 'domain' does not exist on type 'ParsedMailbox | ParsedGroup'.
  Property 'domain' does not exist on type 'ParsedGroup'.ts(2339)
```