### PR TITLE
Fix types for .name field

### DIFF
--- a/lib/email-addresses.d.ts
+++ b/lib/email-addresses.d.ts
@@ -8,14 +8,14 @@ declare module emailAddresses {
     interface ParsedMailbox {
         node?: ASTNode;
         parts: {
-            name: ASTNode;
+            name: ASTNode | null;
             address: ASTNode;
             local: ASTNode;
             domain: ASTNode;
             comments: ASTNode[];
         };
         type: "mailbox";
-        name: string;
+        name: string | null;
         address: string;
         local: string;
         domain: string;


### PR DESCRIPTION
```javascript
> emailAddresses.parseOneAddress("me@leafac.com").name
null
> emailAddresses.parseOneAddress("me@leafac.com").parts.name
null
```