### PR TITLE
Allow use an array as the addressListSeparator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Options:
   * `startAt` - Start the parser at one of `address`, `address-list`, `angle-addr`, `from`, `group`, `mailbox`, `mailbox-list`, `reply-to`, `sender`. Default: `address-list`.
   * `atInDisplayName` - Allow the `@` character in the display name of the email address. Default: `false`.
   * `commaInDisplayName` - Allow the `,` character in the display name of the email address. Default: `false`.
-  * `addressListSeparator` - Specifies the character separating the list of email addresses. Default: `,`.
+  * `addressListSeparator` - Specifies the character separating the list of email addresses. Accept String and Array. e.g. `[",", ";"]`, Default: `,`.
 
 Returns an object with the following properties:
 

--- a/lib/email-addresses.d.ts
+++ b/lib/email-addresses.d.ts
@@ -60,7 +60,7 @@ declare module emailAddresses {
         strict?: boolean;
         atInDisplayName?: boolean;
         commaInDisplayName?: boolean;
-        addressListSeparator?: string;
+        addressListSeparator?: string | string[];
     }
 
     interface ParsedResult {

--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -518,7 +518,12 @@ function parse5322(opts) {
         return wrap('address-list', or(
             and(
                 address,
-                star(and(literal(opts.addressListSeparator), address))
+                star(and(
+                    Array.isArray(opts.addressListSeparator) ?
+                        or.apply(null, opts.addressListSeparator.map(separator => literal(separator))) :
+                        literal(opts.addressListSeparator),
+                    address),
+                )
             ),
             obsAddrList
         )());

--- a/test/email-addresses.js
+++ b/test/email-addresses.js
@@ -107,6 +107,38 @@ test("simple address list function with user-specified list separator", function
     t.end();
 });
 
+test("simple address list function with user-specified list separator array", function (t) {
+    var fxn, result;
+    fxn = addrs.parseAddressList;
+
+    result = fxn({ input: "\"A B,; C\" < a@b.c>; d@e, x@y\n b@c", addressListSeparator: [";", ",", "\n"] }) || [{}, {}];
+    t.notOk(result[0].node, "has no ast information");
+    t.equal(result[0].address, "a@b.c", "full address, semantic only");
+    t.equal(result[0].name, "A B,; C", "display name");
+    t.equal(result[0].local, "a", "local part");
+    t.equal(result[0].domain, "b.c", "domain");
+
+    t.notOk(result[1].node, "has no ast information");
+    t.equal(result[1].address, "d@e", "second address");
+    t.equal(result[1].name, null, "second display name");
+    t.equal(result[1].local, "d", "second local part");
+    t.equal(result[1].domain, "e", "second domain");
+
+    t.notOk(result[2].node, "has no ast information");
+    t.equal(result[2].address, "x@y", "third address");
+    t.equal(result[2].name, null, "third display name");
+    t.equal(result[2].local, "x", "third local part");
+    t.equal(result[2].domain, "y", "third domain");
+
+    t.notOk(result[3].node, "has no ast information");
+    t.equal(result[3].address, "b@c", "fourth address");
+    t.equal(result[3].name, null, "fourth display name");
+    t.equal(result[3].local, "b", "fourth local part");
+    t.equal(result[3].domain, "c", "fourth domain");
+
+    t.end();
+});
+
 test("rfc5322 parser", function (t) {
     var fxn, result;
     fxn = addrs;


### PR DESCRIPTION
Previously, addressListSeparator option is supported. But only one separator is allowed to be defined. In real world scenarios, such as accepting user input, we often need to support multiple separators, such as semicolons, line breaks, etc. This PR allow addressListSeparator to be an array and support multiple separators at the same time.