### PR TITLE
Fix usage as ES6 module

### DIFF
--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -1095,4 +1095,4 @@ if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
     global.emailAddresses = parse5322;
 }
 
-}(this));
+}(globalThis));


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#global_context, 'this' is undefined at top-level when the script is being loaded as module. And this could actually be observed while trying to use email-addresses in a Thunderbird WebExtension:

Uncaught TypeError: global is undefined
    <anonymous> moz-extension://5efae89a-4ceb-4bb0-8179-8e3d26b9dee9/node_modules/email-addresses/lib/email-addresses.js:1095
    <anonymous> moz-extension://5efae89a-4ceb-4bb0-8179-8e3d26b9dee9/node_modules/email-addresses/lib/email-addresses.js:1098